### PR TITLE
Update license badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ VidKit is an intelligent video file management system for media enthusiasts and 
 
 [![Release](https://img.shields.io/github/v/release/tekenstam/vidkit)](https://github.com/tekenstam/vidkit/releases/latest)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/tekenstam/vidkit)](https://golang.org/doc/devel/release.html)
-[![License](https://img.shields.io/github/license/tekenstam/vidkit)](LICENSE)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Tests](https://github.com/tekenstam/vidkit/workflows/Test/badge.svg)](https://github.com/tekenstam/vidkit/actions?query=workflow%3ATest)
 [![Integration Tests](https://github.com/tekenstam/vidkit/workflows/Integration%20Tests/badge.svg)](https://github.com/tekenstam/vidkit/actions?query=workflow%3A%22Integration+Tests%22)
 [![Go Report Card](https://goreportcard.com/badge/github.com/tekenstam/vidkit)](https://goreportcard.com/report/github.com/tekenstam/vidkit)


### PR DESCRIPTION
This commit improves the license badge in the README by:

1. Using a more explicit MIT license badge that directly indicates the license type
2. Updating the badge color to blue for better visibility
3. Maintaining the link to the LICENSE file

This change more clearly communicates VidKit's licensing to potential users and contributors, which is important for a video metadata analysis tool.