### PR TITLE
Fix GoReleaser permissions in GitHub Actions workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write  # Needed for goreleaser to publish releases
+  discussions: write  # Allows creating discussions on release
+  packages: write  # Allows publishing packages if needed in the future
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This commit addresses the '403 Resource not accessible by integration' error by adding explicit permissions to the release workflow:

1. Added 'contents: write' permission needed for publishing releases
2. Added 'discussions: write' to enable release discussions if needed
3. Added 'packages: write' for potential future package publishing

These permission declarations ensure the GitHub token has sufficient authorization to create releases and publish artifacts, which is essential for VidKit's automated release process via GoReleaser.