### PR TITLE
Fix GoReleaser artifact names to match README examples

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,8 +24,8 @@ archives:
         format: zip
     name_template: >-
       {{ .ProjectName }}_
-      {{- title .Os }}_
-      {{- if eq .Arch "amd64" }}x86_64
+      {{- .Os }}_
+      {{- if eq .Arch "amd64" }}amd64
       {{- else }}{{ .Arch }}{{ end }}
     files:
       - README.md

--- a/README.md
+++ b/README.md
@@ -50,20 +50,55 @@ Built with Go 1.21+ and powered by FFmpeg, VidKit brings professional media mana
 
 ## Prerequisites
 
-- Go 1.21 or later
 - FFmpeg (specifically ffprobe) installed on your system
-- TMDb API key (required for metadata lookup)
+- TMDb API key (optional, required only for metadata lookup)
 
 ## Installation
 
-1. Build the tool:
+### Option 1: Download Pre-built Binary (Recommended)
+
+1. Download the latest binary for your platform from the [Releases page](https://github.com/tekenstam/vidkit/releases/latest)
+
+**Linux/macOS**:
 ```bash
+# Download the appropriate binary for your system (examples below)
+# For macOS (Apple Silicon):
+curl -L https://github.com/tekenstam/vidkit/releases/latest/download/vidkit_darwin_arm64.tar.gz -o vidkit.tar.gz
+
+# For macOS (Intel):
+curl -L https://github.com/tekenstam/vidkit/releases/latest/download/vidkit_darwin_amd64.tar.gz -o vidkit.tar.gz
+
+# For Linux (x86_64):
+curl -L https://github.com/tekenstam/vidkit/releases/latest/download/vidkit_linux_amd64.tar.gz -o vidkit.tar.gz
+
+# Extract and install
+tar -xzf vidkit.tar.gz
+chmod +x vidkit
+sudo mv vidkit /usr/local/bin/  # Optional: move to a directory in your PATH
+```
+
+**Windows**:
+1. Download the Windows zip file (`vidkit_windows_amd64.zip`)
+2. Extract the zip file
+3. Optionally, add the extracted directory to your PATH
+
+### Option 2: Build from Source
+
+If you prefer to build from source:
+
+1. Ensure you have Go 1.21 or later installed
+2. Clone the repository and build:
+```bash
+git clone https://github.com/tekenstam/vidkit.git
+cd vidkit
 go build -o vidkit
 ```
 
-2. Set up TMDb API key (required for metadata lookup):
-   - Get a free API key from [TMDb](https://www.themoviedb.org/settings/api)
-   - Add it to `~/.config/vidkit/config.json`:
+### API Key Setup (for metadata features)
+
+Set up a TMDb API key (required only if you want to use metadata features):
+- Get a free API key from [TMDb](https://www.themoviedb.org/settings/api)
+- Add it to `~/.config/vidkit/config.json`:
 ```json
 {
   "tmdb_api_key": "your_api_key_here"
@@ -76,43 +111,43 @@ The tool will create a template config file if none exists and guide you through
 
 Process a single video file:
 ```bash
-./vidkit <video_file>
+vidkit <video_file>
 ```
 
 Process all videos in a directory (recursively):
 ```bash
-./vidkit <directory>
+vidkit --recursive <directory>
 ```
 
 Preview changes without modifying files:
 ```bash
-./vidkit --preview <file_or_directory>
+vidkit --preview <file_or_directory>
 ```
 
 Skip online metadata lookup:
 ```bash
-./vidkit --no-metadata <file_or_directory>
+vidkit --no-metadata <file_or_directory>
 ```
 
 Available options:
 ```
--b             Batch mode: process automatically without interactive prompts
--r             Search recursively in directories
--l             Use lowercase characters in filenames
--s             Use dots in place of spaces (scene style)
---preview       Preview mode: show what would be done without making changes
---no-metadata   Skip online metadata lookup
---no-overwrite  Prevent renaming if it would overwrite a file
---lang <code>   Metadata language (ISO 639-1 code, default: en)
---movie-filename-template  Custom template for movie filenames (e.g., "{title} ({year}) [{resolution}]")
---tv-filename-template     Custom template for TV show filenames (e.g., "{title} S{season:02d}E{episode:02d} {episode_title}")
---separator     Character to use as separator in filenames
---movie-provider Select movie metadata provider (tmdb, omdb)
---tv-provider    Select TV show metadata provider (tvmaze, tvdb)
---organize      Enable/disable organizing files into directory structures (default: true)
---movie-directory-template     Directory template for movies (e.g., "Movies/{title[0]}/{title} ({year})")
---tv-directory-template        Directory template for TV shows (e.g., "TV/{title}/Season {season:02d}")
---version       Show version information
+  -batch               Process files without prompting
+  -recursive           Process directories recursively
+  -lowercase           Convert filenames to lowercase
+  -scene-style         Use dots instead of spaces (scene style)
+  -separator string    Character to use as separator in filenames
+  -preview             Preview mode: show what would be done without making changes
+  -no-metadata         Skip metadata lookup
+  -no-overwrite        Don't overwrite existing files
+  -organize            Organize files into directories
+  -lang string         Metadata language (ISO 639-1 code, default: en)
+  -movie-filename-template string    Template for movie filenames (e.g., '{title} ({year}) [{resolution}]')
+  -tv-filename-template string       Template for TV show filenames (e.g., '{title} S{season:02d}E{episode:02d} {episode_title}')
+  -movie-directory-template string   Template for movie directory organization (e.g., 'Movies/{genre}/{title} ({year})')
+  -tv-directory-template string      Template for TV show directory organization (e.g., 'TV/{genre}/{title}/Season {season:02d}')
+  -movie-provider string    Select movie metadata provider (tmdb, omdb)
+  -tv-provider string       Select TV show metadata provider (tvmaze, tvdb)
+  -version                  Show version information
 ```
 
 ### Supported Video Formats
@@ -193,13 +228,17 @@ Do you want to rename the file? (y/N):
 
 VidKit is built with Go and follows standard Go project practices.
 
-### Building from Source
+### Building From Source
+
+For developers working on VidKit or users who prefer to build from the latest source:
 
 ```bash
 git clone https://github.com/tekenstam/vidkit.git
 cd vidkit
 go build -o vidkit ./cmd/vidkit
 ```
+
+See the [Installation](#installation) section for simpler options using pre-built binaries.
 
 ### Code Quality
 
@@ -253,24 +292,24 @@ To test the TV show metadata functionality with sample files:
 
 2. Test TV show detection in preview mode:
 ```bash
-go run cmd/vidkit/main.go --preview test_videos/Breaking.Bad.S01E01.Pilot.mp4
+vidkit --preview test_videos/Breaking.Bad.S01E01.Pilot.mp4
 ```
 
 3. Test batch processing of multiple formats:
 ```bash
-go run cmd/vidkit/main.go --preview --batch test_videos/*.mp4
+vidkit --preview --batch test_videos/*.mp4
 ```
 
 ### Testing Different Naming Formats
 
 Test with custom TV show format:
 ```bash
-go run cmd/vidkit/main.go --preview --tv-filename-template "{title}.S{season:02d}E{episode:02d}.{episode_title}" test_videos/Breaking.Bad.S01E05.Gray.Matter.mp4
+vidkit --preview --tv-filename-template "{title}.S{season:02d}E{episode:02d}.{episode_title}" test_videos/Breaking.Bad.S01E05.Gray.Matter.mp4
 ```
 
 Test with scene-style naming (dots instead of spaces):
 ```bash
-go run cmd/vidkit/main.go --preview --scene-style test_videos/Breaking.Bad.S01E05.Gray.Matter.mp4
+vidkit --preview --scene-style test_videos/Breaking.Bad.S01E05.Gray.Matter.mp4
 ```
 
 For more detailed testing information, see [CONTRIBUTING.md](CONTRIBUTING.md).


### PR DESCRIPTION
- Update GoReleaser config to use lowercase OS names for consistent artifact naming
- Improve installation documentation with clear download instructions
- Update usage examples to use installed 'vidkit' command assuming PATH installation
- Standardize CLI options documentation in README to match actual command output
- Update all code examples to use the installed binary rather than go run